### PR TITLE
Make test more robust

### DIFF
--- a/src/algoesup/test.py
+++ b/src/algoesup/test.py
@@ -8,7 +8,7 @@ def test(function: Callable, test_table: list) -> None:
 
     Args:
         function (Callable): The function to be tested.
-        test_table (list): The list of tests. Each element of test_table is a list or 
+        test_table (list): The list of tests. Each element of test_table is a list or
             tuple with: a string (the test case name); one or more values (the inputs to the function);
             the expected output value.
     """
@@ -26,8 +26,10 @@ def test(function: Callable, test_table: list) -> None:
             invalid.append(f"test case {num} must have string as first element.")
         elif len(test_case[1:-1]) != expects:
             num_args = len(test_case[1:-1])
-            invalid.append(f"test case \"{test_case[0]}\" has {num_args} input(s) instead of {expects}")
-    if invalid: 
+            invalid.append(
+                f'test case "{test_case[0]}" has {num_args} input(s) instead of {expects}'
+            )
+    if invalid:
         for msg in invalid:
             print(f"Error: {msg}")
         print(not_tested)

--- a/src/algoesup/test.py
+++ b/src/algoesup/test.py
@@ -3,6 +3,24 @@
 from typing import Callable
 
 
+def validate_test_table(function: Callable, test_table: list) -> list:
+    """Validate the structure of a test table"""
+    errors = []
+    if not isinstance(test_table, (list, tuple)):
+        errors.append("The test table must be a list or tuple.")
+        return errors
+    # The number of arguments function expects.
+    expects = function.__code__.co_argcount
+    for num, test_case in enumerate(test_table, start=1):
+        if not isinstance(test_case, (list, tuple)):
+            errors.append(f"Test case {num}: should be a list or tuple.")
+        elif not isinstance(test_case[0], str):
+            errors.append(f"Test case {num}: first element must be a string.")
+        elif len(test_case[1:-1]) != expects:
+            num_args = len(test_case[1:-1])
+            errors.append(f"Test case {num}: {num_args} inputs found instead of {expects}")
+    return errors
+    
 def test(function: Callable, test_table: list) -> None:
     """Test the function with the test_table. Report failed tests.
 
@@ -12,6 +30,13 @@ def test(function: Callable, test_table: list) -> None:
             tuple with: a string (the test case name); one or more values (the inputs to the function);
             the expected output value.
     """
+    if errors := validate_test_table(function, test_table):
+        print("ERROR: invalid test table:")
+        for error in errors:
+            print(error)
+        print(f"{function.__name__} has NOT been tested.")
+        return
+
     print(f"Testing {function.__name__}...")
     passed = failed = 0
     for test_case in test_table:

--- a/src/algoesup/test.py
+++ b/src/algoesup/test.py
@@ -3,24 +3,6 @@
 from typing import Callable
 
 
-def validate_test_table(function: Callable, test_table: list) -> list:
-    """Validate the structure of a test table"""
-    errors = []
-    if not isinstance(test_table, (list, tuple)):
-        errors.append("The test table must be a list or tuple.")
-        return errors
-    # The number of arguments function expects.
-    expects = function.__code__.co_argcount
-    for num, test_case in enumerate(test_table, start=1):
-        if not isinstance(test_case, (list, tuple)):
-            errors.append(f"Test case {num}: should be a list or tuple.")
-        elif not isinstance(test_case[0], str):
-            errors.append(f"Test case {num}: first element must be a string.")
-        elif len(test_case[1:-1]) != expects:
-            num_args = len(test_case[1:-1])
-            errors.append(f"Test case {num}: {num_args} inputs found instead of {expects}")
-    return errors
-    
 def test(function: Callable, test_table: list) -> None:
     """Test the function with the test_table. Report failed tests.
 
@@ -30,23 +12,37 @@ def test(function: Callable, test_table: list) -> None:
             tuple with: a string (the test case name); one or more values (the inputs to the function);
             the expected output value.
     """
-    if errors := validate_test_table(function, test_table):
-        print("ERROR: invalid test table:")
-        for error in errors:
-            print(error)
-        print(f"{function.__name__} has NOT been tested.")
+    not_tested = f"The test table is invalid, {function.__name__} has NOT been tested."
+    if not isinstance(test_table, (list, tuple)):
+        print(f"Error: The test table must be a list or tuple.\n{not_tested}")
         return
-
-    print(f"Testing {function.__name__}...")
-    passed = failed = 0
-    for test_case in test_table:
-        name = test_case[0]
-        inputs = test_case[1:-1]
-        expected = test_case[-1]
-        actual = function(*inputs)
-        if actual != expected:
-            print(name, "FAILED:", actual, "instead of", expected)
-            failed += 1
-        else:
-            passed += 1
-    print("Tests finished:", passed, "passed,", failed, "failed.")
+    # The number of arguments function expects.
+    expects = function.__code__.co_argcount
+    invalid = []
+    for num, test_case in enumerate(test_table, start=1):
+        if not isinstance(test_case, (list, tuple)):
+            invalid.append(f"test case {num} must be a list or tuple.")
+        elif not isinstance(test_case[0], str):
+            invalid.append(f"test case {num} must have string as first element.")
+        elif len(test_case[1:-1]) != expects:
+            num_args = len(test_case[1:-1])
+            invalid.append(f"test case \"{test_case[0]}\" has {num_args} input(s) instead of {expects}")
+    if invalid: 
+        for msg in invalid:
+            print(f"Error: {msg}")
+        print(not_tested)
+        return
+    else:
+        print(f"Testing {function.__name__}...")
+        passed = failed = 0
+        for test_case in test_table:
+            name = test_case[0]
+            inputs = test_case[1:-1]
+            expected = test_case[-1]
+            actual = function(*inputs)
+            if actual != expected:
+                print(name, "FAILED:", actual, "instead of", expected)
+                failed += 1
+            else:
+                passed += 1
+        print("Tests finished:", passed, "passed,", failed, "failed.")


### PR DESCRIPTION
Add function `validate_test_table` to confirm:
 - the table is list or tuple
 - each case is list or tuple
 - first element of each case is str
 - each case has correct number of args
 
At present, no testing is done if any part of the table is invalid.

If the table is not a list or tuple, none of the other conditions are checked. Then for each case there is a hierarchy of conditions to pass i.e when one fails, the error is noted and we move on to the next case.

I've tried to make the messaging clear, but it probably still needs a few tweaks here and there, and certainly needs a second opinion :smile:.
