### PR TITLE
Fix #51: use stdin for ruff

### DIFF
--- a/src/algoesup/magics.py
+++ b/src/algoesup/magics.py
@@ -271,7 +271,7 @@ def run_checkers(result) -> None:
     cell_code = TransformerManager().transform_cell(result.info.raw_cell)
     for checker in active:
         command, display = checkers[checker]
-        # Avoid I/O overhead for ruff by using stdin.
+        # Use "-" option for ruff to accept stdin and avoid file I/O.
         if checker == "ruff":
             ruff_command = command + [
                 "-",

--- a/src/algoesup/magics.py
+++ b/src/algoesup/magics.py
@@ -267,37 +267,59 @@ def run_checkers(result) -> None:
     """Run all active checkers after a cell is executed."""
     if not active:
         return
-    try:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as temp:
-            # transform IPython to pure Python to avoid linters reporting syntax errors
-            temp.write(TransformerManager().transform_cell(result.info.raw_cell))
-            # Handle Windows file paths
-            temp_name = temp.name.replace("\\", "/")
-        for checker in active:
-            command, display = checkers[checker]
-            lint_file = command + [temp_name]
+    # transform IPython to pure Python to avoid linters reporting syntax errors
+    cell_code = TransformerManager().transform_cell(result.info.raw_cell)
+    for checker in active:
+        command, display = checkers[checker]
+        # Avoid I/O overhead for ruff by using stdin.
+        if checker == "ruff":
+            ruff_command = command + [
+                "-",
+                "--stdin-filename",
+                "notebook_cell.py",
+            ]
             try:
                 output = subprocess.run(
-                    lint_file,
+                    ruff_command,
+                    input=cell_code,
                     capture_output=True,
                     text=True,
                     check=False,
                 )
-                display(checker, output, temp_name)
+                display(checker, output, "notebook_cell.py")
             except Exception as e:
-                print(f"Error on executing {command[0]}:\n{e}")
-    except Exception as e:
-        print(f"Error on writing cell to a temporary file:\n{e}")
-    finally:
-        os.remove(temp_name)
+                print(f"Error on executing {checker}:\n{e}")
+        else:
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".py", delete=False
+                ) as temp:
+                    temp.write(cell_code)
+                    # Handle Windows file paths
+                    temp_name = temp.name.replace("\\", "/")
+                lint_file_command = command + [temp_name]
+                try:
+                    output = subprocess.run(
+                        lint_file_command,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    display(checker, output, temp_name)
+                except Exception as e:
+                    print(f"Error on executing {checker}:\n{e}")
+            except Exception as e:
+                print(f"Error on writing cell to a temporary file:\n{e}")
+            finally:
+                os.remove(temp_name)
 
 
 def load_ipython_extension(ipython):
-    """Load the ipython extension, and register run_checkers with post_cell_run
+    """Load the Ipython extension, and register run_checkers with post_cell_run.
 
-    This function hooks into the ipython extension system so the magic commands defined
-    in this module can be loaded with `load_ext algoesup.magics`. It also registers
+    Hook into the Ipython extension system so the magic commands defined
+    in this module can be loaded with `load_ext algoesup.magics`. Additionally, register
     `run_checkers` with the `post_run_cell` event so the linters are run with the
-    contents of each ipython cell after it has been executed.
+    contents of each Ipython cell after it has been executed.
     """
     ipython.events.register("post_run_cell", run_checkers)  # type: ignore[name-defined]


### PR DESCRIPTION
Ruff  uses the `-` option in combination with `subprocess.run`'s `input=str` to read directly from `str` through stdin.

Tested on the example essays, including the coding guide, and TMA's 1, 2 and 3, with and without `notebook_cell.py` files in the same directory.

Additionally made minor modifications to the docstring of `load_ipython_extension`