### PR TITLE
Fix #73 and the UTF-8 encoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ This project does *not* adhere to [Semantic Versioning](https://semver.org).
 ## [Unreleased](https://github.com/dsa-ou/algoesup/compare/v0.4.2...HEAD)
 These changes are in the GitHub repository but not on [PyPI](https://pypi.org/project/algoesup).
 
-Nothing yet.
+<!-- Nothing yet. -->
+
+### Fixed
+- read multi-byte characters in Windows
+- don't crash if temporary file isn't created for a cell
 
 ## [0.4.2](https://github.com/dsa-ou/algoesup/compare/v0.4.1...v0.4.2) - 2025-08-29
 ### Fixed

--- a/src/algoesup/magics.py
+++ b/src/algoesup/magics.py
@@ -318,6 +318,7 @@ def run_checkers(result) -> None:
                     capture_output=True,
                     text=True,
                     check=False,
+                    encoding="utf-8",
                 )
                 display(checker, output, "notebook_cell.py")
             except Exception as e:

--- a/src/algoesup/magics.py
+++ b/src/algoesup/magics.py
@@ -323,9 +323,10 @@ def run_checkers(result) -> None:
             except Exception as e:
                 print(f"Error on executing {checker}:\n{e}")
         else:
+            temp_name = None
             try:
                 with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".py", delete=False
+                    mode="w", suffix=".py", delete=False, encoding="utf-8"
                 ) as temp:
                     temp.write(cell_code)
                     # Handle Windows file paths
@@ -337,6 +338,7 @@ def run_checkers(result) -> None:
                         capture_output=True,
                         text=True,
                         check=False,
+                        encoding="utf-8",
                     )
                     display(checker, output, temp_name)
                 except Exception as e:
@@ -344,7 +346,8 @@ def run_checkers(result) -> None:
             except Exception as e:
                 print(f"Error on writing cell to a temporary file:\n{e}")
             finally:
-                os.remove(temp_name)
+                if temp_name:
+                    os.remove(temp_name)
 
 
 def load_ipython_extension(ipython):

--- a/tests/test_magics.py
+++ b/tests/test_magics.py
@@ -308,7 +308,7 @@ allowed_tests = [
         id="index: 0, allowed: import numpy",
     ),
     pytest.param(
-        's = f"this is an f-string"',
+        's = f"this—is—an—f-string"',
         ALLOWED_FOUND + allowed_issue(1, "f-string"),
         id="index: 1, allowed: f-string",
     ),

--- a/tests/test_magics.py
+++ b/tests/test_magics.py
@@ -161,7 +161,7 @@ ruff_defaults_tests = [
         id="index: 3, ruff: E741",
     ),
     pytest.param(
-        'def function(x):\n    """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor purus ut ex fermentum, at maximus est hendrerit."""\n    pass',
+        'def function(x):\n    """Lorem ipsum—dolor≤sit amet, consectetur—adipiscing elit. Duis auctor purus ut ex fermentum, at maximus est hendrerit."""\n    pass',
         RUFF_FOUND
         + ruff_warning(1, "ANN201", name="function", type="None")
         + "\n"


### PR DESCRIPTION
Fix the UTF-8 encoding bug that would cause linters to crash on multi-byte characters and Fix #73:
  - all  standard automated tests pass on Windows and Linux
  - multi-byte characters no longer crash linters on Windows
  - `temp_name` no longer crashes linters when not set